### PR TITLE
Add violations for com.google.inject.Inject and com.google.inject.Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.10</version>

--- a/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
@@ -27,11 +27,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.InstructionAdapter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -167,6 +169,16 @@ final class ModernizerClassVisitor extends ClassVisitor {
                     name = "\"<init>\"";
                 }
                 visitFieldOrMethod(owner, name, desc);
+            }
+
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc,
+                    boolean visible) {
+                String name = Type.getType(desc).getInternalName();
+                Violation violation = violations.get(name);
+                checkToken(name, violation, name, lineNumber);
+
+                return super.visitAnnotation(desc, visible);
             }
 
             private void visitFieldOrMethod(String owner, String name,

--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -594,4 +594,16 @@ violation names use the same format that javap emits.
     <comment>Prefer java.util.Base64.Encoder.encodeToString(byte[])</comment>
   </violation>
 
+  <violation>
+    <name>com/google/inject/Inject</name>
+    <version>1.5</version>
+    <comment>Prefer javax.inject.Inject</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/inject/Provider</name>
+    <version>1.5</version>
+    <comment>Prefer javax.inject.Provider</comment>
+  </violation>
+
 </modernizer>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -53,6 +53,8 @@ import com.google.common.primitives.Shorts;
 import com.google.common.primitives.UnsignedInts;
 import com.google.common.primitives.UnsignedLongs;
 import com.google.common.util.concurrent.Atomics;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
@@ -278,6 +280,10 @@ public final class ModernizerTest {
                 new ClassReader(VoidPredicate.class.getName())));
         occurrences.addAll(modernizer.check(
                 new ClassReader(VoidSupplier.class.getName())));
+        occurrences.addAll(modernizer.check(
+                new ClassReader(InjectMethod.class.getName())));
+        occurrences.addAll(modernizer.check(
+                new ClassReader(ObjectProvider.class.getName())));
 
         Collection<Violation> actualViolations = Lists.newArrayList();
         for (ViolationOccurrence occurrence : occurrences) {
@@ -347,6 +353,20 @@ public final class ModernizerTest {
         @TestAnnotation
         public void annotatedMethod() {
             // Nothing
+        }
+    }
+
+    private static class InjectMethod {
+        @Inject
+        public InjectMethod() {
+            // Nothing
+        }
+    }
+
+    private static class ObjectProvider implements Provider<Object> {
+        @Override
+        public Object get() {
+            return new Object();
         }
     }
 

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -251,6 +251,22 @@ public final class ModernizerTest {
     }
 
     @Test
+    public void testAnnotationViolation() throws Exception {
+        String name = TestAnnotation.class.getName().replace('.', '/');
+        Map<String, Violation> testViolations = Maps.newHashMap();
+        testViolations.put(name,
+                new Violation(name, 5, ""));
+        Modernizer modernizer = new Modernizer("1.5", testViolations,
+                NO_EXCLUSIONS, NO_IGNORED_PACKAGES);
+        ClassReader cr = new ClassReader(AnnotatedMethod.class.getName());
+        Collection<ViolationOccurrence> occurences =
+                modernizer.check(cr);
+        assertThat(occurences).hasSize(1);
+        assertThat(occurences.iterator().next().getViolation().getName())
+                .isEqualTo(name);
+    }
+
+    @Test
     public void testAllViolations() throws Exception {
         Modernizer modernizer = createModernizer("1.8");
         Collection<ViolationOccurrence> occurrences = modernizer.check(
@@ -320,6 +336,17 @@ public final class ModernizerTest {
         @Override
         public Void get() {
             return null;
+        }
+    }
+
+    private @interface TestAnnotation {
+        // Nothing
+    }
+
+    private static class AnnotatedMethod {
+        @TestAnnotation
+        public void annotatedMethod() {
+            // Nothing
         }
     }
 


### PR DESCRIPTION
These are (almost) always replaceable with the javax.inject variants, which would also
work with other DI frameworks.