### PR TITLE
Check annotation classes for violations

### DIFF
--- a/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
@@ -27,11 +27,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.InstructionAdapter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -167,6 +169,16 @@ final class ModernizerClassVisitor extends ClassVisitor {
                     name = "\"<init>\"";
                 }
                 visitFieldOrMethod(owner, name, desc);
+            }
+
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc,
+                    boolean visible) {
+                String name = Type.getType(desc).getInternalName();
+                Violation violation = violations.get(name);
+                checkToken(name, violation, name, lineNumber);
+
+                return super.visitAnnotation(desc, visible);
             }
 
             private void visitFieldOrMethod(String owner, String name,

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -251,6 +251,22 @@ public final class ModernizerTest {
     }
 
     @Test
+    public void testAnnotationViolation() throws Exception {
+        String name = TestAnnotation.class.getName().replace('.', '/');
+        Map<String, Violation> testViolations = Maps.newHashMap();
+        testViolations.put(name,
+                new Violation(name, 5, ""));
+        Modernizer modernizer = new Modernizer("1.5", testViolations,
+                NO_EXCLUSIONS, NO_IGNORED_PACKAGES);
+        ClassReader cr = new ClassReader(AnnotatedMethod.class.getName());
+        Collection<ViolationOccurrence> occurences =
+                modernizer.check(cr);
+        assertThat(occurences).hasSize(1);
+        assertThat(occurences.iterator().next().getViolation().getName())
+                .isEqualTo(name);
+    }
+
+    @Test
     public void testAllViolations() throws Exception {
         Modernizer modernizer = createModernizer("1.8");
         Collection<ViolationOccurrence> occurrences = modernizer.check(
@@ -320,6 +336,17 @@ public final class ModernizerTest {
         @Override
         public Void get() {
             return null;
+        }
+    }
+
+    private @interface TestAnnotation {
+        // Nothing
+    }
+
+    private static class AnnotatedMethod {
+        @TestAnnotation
+        public void annotatedMethod() {
+            // Nothing
         }
     }
 


### PR DESCRIPTION
This adds support for flagging violations for wrong annotation classes. This is a requirement for #23.

Note that the test does not rely on any specific invalid annotation, but uses its own dummy annotation.