### PR TITLE
Detect two variations of Preconditions.checkNotNull

### DIFF
--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -595,6 +595,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>com/google/common/base/Preconditions.checkNotNull:(Ljava/lang/Object;)Ljava/lang/Object;</name>
+    <version>1.7</version>
+    <comment>Prefer java.util.Objects.requireNonNull(Object)</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/common/base/Preconditions.checkNotNull:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;</name>
+    <version>1.8</version>
+    <comment>Prefer java.util.Objects.requireNonNull(Object, String) or java.util.Objects.requireNonNull(Object, Supplier&lt;String&gt;)</comment>
+  </violation>
+
+  <violation>
     <name>com/google/inject/Inject</name>
     <version>1.5</version>
     <comment>Prefer javax.inject.Inject</comment>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -39,6 +39,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
@@ -468,6 +469,8 @@ public final class ModernizerTest {
             FileUtils.readLines((File) null, "");
             new BASE64Decoder().decodeBuffer("");
             new BASE64Encoder().encode((byte[]) null);
+            Preconditions.checkNotNull(new Object());
+            Preconditions.checkNotNull(new Object(), new Object());
         }
     }
 


### PR DESCRIPTION
Details in the commit message:

    Guava provides three versions of Preconditions.checkNotNull:
    - One that doesn't take a custom exception message.
    - One that lazily converts an arbitrary object into an exception message, using
      String#valueOf, if necessary.
    - One that constructs an exception message based on a given format pattern and
      zero or more arguments.
    
    The third one has no equally-convenient (i.e. concise) counterpart in any
    version of Java. But the first two do, in Java 7 and 8, respectively:
    - Java 8 allows one to provide a Supplier for the lazy message construction,
      which support for lambda expressions makes trivial.
    - Strictly speaking Java 7 also provides an alternative for the second variant,
      but it's more restricted signature means that it doesn't have the nice lazy
      string construction semantics. Hence the decision to only warn for that
      variant when Java 8 is used.
