### PR TITLE
Add a skip flag.

### DIFF
--- a/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -74,10 +74,23 @@ public final class ModernizerMojo extends AbstractMojo {
 
     private Modernizer modernizer;
 
+    /**
+     * Skips the plugin execution.
+     *
+     * @since 1.4.0
+     */
+    @Parameter(defaultValue = "false", property = "modernizer.skip")
+    protected boolean skip = false;
+
     @Override
     public void execute() throws MojoExecutionException {
         Map<String, Violation> violations;
         InputStream is;
+        if (skip) {
+            getLog().info("Skipping modernizer execution!");
+            return;
+        }
+
         if (violationsFile == null) {
             is = Modernizer.class.getResourceAsStream("/modernizer.xml");
         } else {


### PR DESCRIPTION
This allows to skip plugin execution with

```
<configuration>
  <skip>true</skip>
</configuration>
```

or -Dmodernizer.skip=true from the command line.

Every plugin should have a "skip" flag.