### PR TITLE
Add support for specifying exclusions in the POM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The `<configuration>` stanza can contain several elements:
 * `<includeTestClasses>` run Modernizer on test classes.  Defaults to true.
 * `<violationsFile>` user-specified violation file.  Also disables standard violation checks.
 * `<exclusionsFile>` disables user-specified violations.  This is a text file with one exclusion per line in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.
+* `<exclusions>` violations to disable. Each exclusion should be in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.
 * `<ignorePackages>` package prefixes to ignore, specified using `<ignorePackage>` child elements. Specifying `foo.bar` subsequently ignores `foo.bar.*`, `foo.bar.baz.*` and so on.
 
 To run Modernizer during the verify phase of your build, add the following to

--- a/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -92,6 +92,14 @@ public final class ModernizerMojo extends AbstractMojo {
     private String exclusionsFile = null;
 
     /**
+     * Violations to disable. Each exclusion should be in the javap format:
+     *
+     * java/lang/String.getBytes:(Ljava/lang/String;)[B.
+     */
+    @Parameter
+    private Set<String> exclusions = new HashSet<String>();
+
+    /**
      * Package prefixes to ignore, specified using &lt;ignorePackage&gt; child
      * elements. Specifying foo.bar subsequently ignores foo.bar.*,
      * foo.bar.baz.* and so on.
@@ -144,7 +152,8 @@ public final class ModernizerMojo extends AbstractMojo {
             Utils.closeQuietly(is);
         }
 
-        Set<String> exclusions = new HashSet<String>();
+        Set<String> allExclusions = new HashSet<String>();
+        allExclusions.addAll(exclusions);
         if (exclusionsFile != null) {
             is = null;
             try {
@@ -160,7 +169,7 @@ public final class ModernizerMojo extends AbstractMojo {
                             "Could not find exclusion file: " + exclusionsFile);
                 }
 
-                exclusions.addAll(Utils.readAllLines(is));
+                allExclusions.addAll(Utils.readAllLines(is));
             } catch (IOException ioe) {
                 throw new MojoExecutionException(
                         "Error reading exclusion file: " + exclusionsFile, ioe);
@@ -169,7 +178,7 @@ public final class ModernizerMojo extends AbstractMojo {
             }
         }
 
-        modernizer = new Modernizer(javaVersion, violations, exclusions,
+        modernizer = new Modernizer(javaVersion, violations, allExclusions,
                 ignorePackages);
 
         try {


### PR DESCRIPTION
This change allows one to specify exclusions as part of the plugin configuration. Example:

    <configuration> 
        <exclusions>    
            <exclusion>org/joda/time/DateTime."&lt;init&gt;":(J)V</exclusion>
        </exclusions>   
    </configuration
 
This is more convenient than the `<exclusionsFile>` setting when one wishes to suppress certain violations across a multi-module build, because the plugin configuration can be placed in the parent POM and be made to apply to all submodules.

(The `<exclusionsFile>`, by contrast, either requires one to specify an absolute file, or create many violation files, one for each `pom.xml` in the build, all with the same relative path. I'm aware that that the exclusions file can also be read from the plugin's classpath, but that'd require me to package the violations file in a separate JAR and declare it as a plugin dependency. Also not nearly as convenient as the solution proposed here.)

Interested to hear what you think :)