### PR TITLE
#57 Violation for EMPTY Collections constants

### DIFF
--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -619,6 +619,24 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/util/Collections.EMPTY_LIST:Ljava/util/List;</name>
+    <version>1.5</version>
+    <comment>Prefer java.util.Collections.emptyList()</comment>
+  </violation>
+
+  <violation>
+    <name>java/util/Collections.EMPTY_MAP:Ljava/util/Map;</name>
+    <version>1.5</version>
+    <comment>Prefer java.util.Collections.emptyMap()</comment>
+  </violation>
+
+  <violation>
+    <name>java/util/Collections.EMPTY_SET:Ljava/util/Set;</name>
+    <version>1.5</version>
+    <comment>Prefer java.util.Collections.emptySet()</comment>
+  </violation>
+
+  <violation>
     <name>java/util/Hashtable."&lt;init&gt;":(IF)V</name>
     <version>1.2</version>
     <comment>Prefer java.util.HashMap</comment>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -606,6 +606,9 @@ public final class ModernizerTest {
             Period.parse("");
             new Period(DateTime.now(), DateTime.now());
             DateTimeFormat.forPattern("");
+            object = Collections.EMPTY_LIST;
+            object = Collections.EMPTY_MAP;
+            object = Collections.EMPTY_SET;
         }
     }
 


### PR DESCRIPTION
Adding violations for `Collections.EMPTY_LIST`, `EMPTY_MAP`, and `EMPTY_SET` to prefer the more modern `emptyList()`, etc. methods which are actually type safe.